### PR TITLE
Provide srt-qualizer CLI command

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,9 @@ srt = "^3.5.3"
 [tool.poetry.group.dev.dependencies]
 pytest = ">=7.2.2,<9.0.0"
 
+[tool.poetry.scripts]
+srt-equalizer = "srt_equalizer.cli:main"
+
 [build-system]
 requires = ["poetry-core>=1.0.0"]
 build-backend = "poetry.core.masonry.api"

--- a/src/srt_equalizer/cli.py
+++ b/src/srt_equalizer/cli.py
@@ -1,0 +1,21 @@
+import argparse
+import srt_equalizer
+
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Equalize SRT file line lengths.")
+    parser.add_argument("input_file", type=str, help="Path to the input SRT file.")
+    parser.add_argument("output_file", type=str, help="Path to the output SRT file.")
+    parser.add_argument("--max-line-length", type=int, default=42, help="Maximum line length in characters.")
+    parser.add_argument(
+        "--method",
+        type=str,
+        choices=["greedy", "halving", "punctuation"],
+        default="greedy",
+        help="Method for equalizing line lengths: 'greedy', 'halving', or 'punctuation'."
+    )
+
+    args = parser.parse_args()
+
+    srt_equalizer.equalize_srt_file(args.input_file, args.output_file, args.max_line_length, args.method)


### PR DESCRIPTION
Add a CLI python file to expose a `srt-equalizer` command for equalizing files. It duplicates declarations of valid entries and default values.